### PR TITLE
Integrate Game Center scoring

### DIFF
--- a/SnakeG/Model/Snake.swift
+++ b/SnakeG/Model/Snake.swift
@@ -22,6 +22,10 @@ class Snake: ObservableObject {
             scoreLabel = "score: \(score)"
         }
     }
+
+    func didEatFood() {
+        score += 1
+    }
     
     func changeDirection () {
         let posX = posArray[0].x
@@ -78,6 +82,7 @@ class Snake: ObservableObject {
         snakeSize = 10
         isStarted = true
         dir = direction.down
+        score = 0
     }
 }
 

--- a/SnakeG/SnakeG.entitlements
+++ b/SnakeG/SnakeG.entitlements
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
+        <key>aps-environment</key>
+        <string>development</string>
+        <key>com.apple.developer.game-center</key>
+        <true/>
 </dict>
 </plist>

--- a/SnakeG/SnakeGApp.swift
+++ b/SnakeG/SnakeGApp.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 import Firebase
+import GameKit
+import UIKit
 
 @main
 struct SnakeGApp: App {
@@ -23,9 +25,71 @@ struct SnakeGApp: App {
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         FirebaseApp.configure()
+        GameCenterManager.shared.authenticateUser()
         //MARK: Test code to crash the app and make sure Crashlytics is working properly
         //        let x: Int? = nil
         //        let y = x!
         return true
+    }
+}
+
+final class GameCenterManager: NSObject {
+    static let shared = GameCenterManager()
+
+    private let leaderboardIdentifier = "snakeg_leaderboard"
+    private var isAuthenticated = false
+
+    private override init() {
+        super.init()
+    }
+
+    func authenticateUser() {
+        GKLocalPlayer.local.authenticateHandler = { [weak self] viewController, error in
+            if let authenticationVC = viewController {
+                self?.presentGameCenter(authenticationVC)
+            } else if let error = error {
+                print("Game Center authentication error: \(error.localizedDescription)")
+            } else {
+                self?.isAuthenticated = GKLocalPlayer.local.isAuthenticated
+            }
+        }
+    }
+
+    func submit(score: Int) {
+        guard isAuthenticated else {
+            print("Game Center score submission skipped: player not authenticated")
+            return
+        }
+
+        let scoreReporter = GKScore(leaderboardIdentifier: leaderboardIdentifier)
+        scoreReporter.value = Int64(score)
+
+        GKScore.report([scoreReporter]) { error in
+            if let error = error {
+                print("Failed to report score to Game Center: \(error.localizedDescription)")
+            } else {
+                print("Successfully reported score \(score) to Game Center")
+            }
+        }
+    }
+
+    private func presentGameCenter(_ viewController: UIViewController) {
+        guard let rootViewController = Self.rootViewController() else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            if rootViewController.presentedViewController == nil {
+                rootViewController.present(viewController, animated: true)
+            }
+        }
+    }
+
+    private static func rootViewController() -> UIViewController? {
+        return UIApplication.shared.connectedScenes
+            .compactMap { scene in
+                (scene as? UIWindowScene)?.windows.first { $0.isKeyWindow }
+            }
+            .first?.rootViewController
     }
 }

--- a/SnakeG/View/SnakeGameView.swift
+++ b/SnakeG/View/SnakeGameView.swift
@@ -117,6 +117,7 @@ struct SnakeGameView: View {
                 if !snake.gameOver {
                     snake.changeDirection()
                     if snake.posArray[0] == thisGame.foodPos {
+                        snake.didEatFood()
                         snake.posArray.append(snake.posArray[0])
                         thisGame.foodPos = thisGame.changeRectPos(snakeSize: snake.snakeSize)
                         thisGame.timePassed = thisGame.timePassed / 2
@@ -124,10 +125,11 @@ struct SnakeGameView: View {
                         let tempArr = snake.posArray.dropFirst()
                         if tempArr.contains(snake.posArray[0]) {
                             print("No no - You are done! game over!")
+                            GameCenterManager.shared.submit(score: snake.score)
                             snake.gameOver.toggle()
                         }
                     }
-                    
+
                 }
             }
             .padding(EdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20))


### PR DESCRIPTION
## Summary
- add a Game Center manager to authenticate the local player and submit leaderboard scores
- enable the Game Center entitlement required for score reporting
- track round scores during gameplay and post them when a run ends

## Testing
- not run (iOS project)


------
https://chatgpt.com/codex/tasks/task_e_68d85b25a240832c8faab32b75a2fecb